### PR TITLE
check nextTick exists before using

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
 var defer;
 
-if (typeof process === 'object') {
+if (typeof process === 'object' && process.nextTick) {
   defer = process.nextTick;
 } else if (typeof Promise === 'function') {
   var resolve = Promise.resolve();

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
 var defer;
 
-if (typeof process === 'object' && process.nextTick) {
+if (typeof process === 'object' && typeof process.nextTick === 'function') {
   defer = process.nextTick;
 } else if (typeof Promise === 'function') {
   var resolve = Promise.resolve();


### PR DESCRIPTION
in react-native, process exists for the sake of holding process.env (or maybe this is coming from a polyfill?)

either way, it seems sensible to check for process.nextTick before using it.

